### PR TITLE
chore: gitignore files ignore lint

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -40,5 +40,10 @@
       "lineWidth": 100,
       "quoteProperties": "asNeeded"
     }
+  },
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
   }
 }


### PR DESCRIPTION
- gitignoreに登録されているファイルはlintしないように修正
  - hcmの自動生成ファイルがlintに引っかかって怒られるため