### PR TITLE
環境変数を修正

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,4 +16,4 @@ GOOGLEFIT_CLIENT_SECRET=your_googlefit_client_secret
 GOOGLEFIT_REDIRECT_URI=your_googlefit_redirect_uri
 
 # Iron Session
-IRON_SESSION_SECRET=your_iron_session_secret
+IRON_SESSION_PASSWORD=your_iron_session_secret


### PR DESCRIPTION
- envValue側とenv.sample側の変数命名が一致していないため、envValueにアクセスするとundefinedで落ちていた問題を修正