### PR TITLE
ログインページを実装

### DIFF
--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -16,5 +16,5 @@ export const GET = async (req: NextRequest) => {
   session.expiresAt = response.expiry_date ?? undefined
   await session.save()
 
-  return NextResponse.redirect('http://localhost:3000/')
+  return NextResponse.redirect('http://localhost:3000/app/login/google')
 }

--- a/src/app/api/auth/spotify/callback/route.ts
+++ b/src/app/api/auth/spotify/callback/route.ts
@@ -17,5 +17,5 @@ export const GET = async (req: NextRequest) => {
   session.expiresAt = Date.now() + response.expires_in * 1000
   await session.save()
 
-  return NextResponse.redirect('http://localhost:3000/')
+  return NextResponse.redirect('http://localhost:3000/app')
 }

--- a/src/app/api/auth/spotify/login/route.ts
+++ b/src/app/api/auth/spotify/login/route.ts
@@ -1,8 +1,6 @@
-import { SPOTIFY_CLIENT_ID } from '@/common/envValues'
+import { SPOTIFY_CLIENT_ID, SPOTIFY_REDIRECT_URI } from '@/common/envValues'
 import { generateRandomString } from '@/utils/randomString'
 import { NextResponse } from 'next/server'
-
-const redirectUri = 'http://localhost:3000/api/auth/spotify/callback'
 
 const scope = [
   'playlist-modify-public',
@@ -16,7 +14,7 @@ export const GET = async () => {
     response_type: 'code',
     client_id: SPOTIFY_CLIENT_ID,
     scope: scope.join(' '),
-    redirect_uri: redirectUri,
+    redirect_uri: SPOTIFY_REDIRECT_URI,
     state: generateRandomString(16),
   })
 

--- a/src/app/app/login/google/page.tsx
+++ b/src/app/app/login/google/page.tsx
@@ -1,0 +1,18 @@
+import { getGoogleAccessToken } from '@/common/auth/Google/getAccessToken'
+import { GoogleLoginButton } from '@/components/auth/GoogleLoginButton'
+import { redirect } from 'next/navigation'
+
+const Home = async () => {
+  const googleToken = await getGoogleAccessToken()
+  if (googleToken !== undefined) return redirect('/app/login/spotify')
+
+  return (
+    <div>
+      <h1>GoogleFit連携</h1>
+      <p>ヘルスケアデータ取得のためにGoogleにログインしてください</p>
+      <GoogleLoginButton />
+    </div>
+  )
+}
+
+export default Home

--- a/src/app/app/login/spotify/page.tsx
+++ b/src/app/app/login/spotify/page.tsx
@@ -1,0 +1,18 @@
+import { getSpotifyAccessToken } from '@/common/auth/Spotify/getAccessToken'
+import { SpotifyLoginButton } from '@/components/auth/SpotifyLoginButton'
+import { redirect } from 'next/navigation'
+
+const Home = async () => {
+  const spotifyToken = await getSpotifyAccessToken()
+  if (spotifyToken !== undefined) return redirect('/app')
+
+  return (
+    <div>
+      <h1>Spotify連携</h1>
+      <p>音楽再生やプレイリスト作成のためにSpotifyにログインしてください。</p>
+      <SpotifyLoginButton />
+    </div>
+  )
+}
+
+export default Home

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,0 +1,14 @@
+import { getGoogleAccessToken } from '@/common/auth/Google/getAccessToken'
+import { getSpotifyAccessToken } from '@/common/auth/Spotify/getAccessToken'
+import { redirect } from 'next/navigation'
+
+const Home = async () => {
+  const googleToken = await getGoogleAccessToken()
+  if (googleToken === undefined) redirect('/app/login/google')
+  const spotifyToken = await getSpotifyAccessToken()
+  if (spotifyToken === undefined) redirect('/app/login/spotify')
+
+  return <div>app</div>
+}
+
+export default Home

--- a/src/common/auth/Spotify/authorize.ts
+++ b/src/common/auth/Spotify/authorize.ts
@@ -5,7 +5,7 @@ export const spotifyAuthorize = async (code: string) => {
   const params = new URLSearchParams({
     grant_type: 'authorization_code',
     code,
-    SPOTIFY_REDIRECT_URI,
+    redirect_uri: SPOTIFY_REDIRECT_URI,
   })
   const buffer = Buffer.from(`${SPOTIFY_CLIENT_ID}:${SPOTIFY_CLIENT_SECRET}`, 'utf-8')
   const headers = new Headers({
@@ -20,7 +20,6 @@ export const spotifyAuthorize = async (code: string) => {
   })
 
   const data = await response.json()
-  console.log(data)
   const parsed: SpotifyAuthResponse = spotifyAuthResponseScheme.parse(data)
   return parsed
 }


### PR DESCRIPTION
- `/app`
  - google未認証 -> `/app/login/google`へリダイレクト
  - spotify未認証 -> `/app/login/spotify`へリダイレクト
- `/app/login/google`
  - Googleログインボタン
  - google認証済み -> `/app/login/spotify`へリダイレクト
- `/app/login/spotify`
  - Spotifyログインボタン
  - spotify認証済み -> `/app`へリダイレクト

![image](https://github.com/INIAD-ts/caravan-tokyo/assets/131662659/3bb235ff-7565-4f53-a983-983ce59ef201)
(Spotifyもほぼ同じ見た目なので割愛)