### PR TITLE
プレイリスト作成のリンクを変更

### DIFF
--- a/src/app/app/_components/SelectPlayList.tsx
+++ b/src/app/app/_components/SelectPlayList.tsx
@@ -32,7 +32,7 @@ export const SelectPlayList = ({ selectedId, handleSelect }: Props) => {
   return playlists.length === 0 ? (
     <div className={styles.noPlaylist}>
       <p>プレイリストが見つかりませんでした。</p>
-      <Link href="/app/playlist/create">
+      <Link href="https://open.spotify.com">
         <Button
           Icon={IconMusicPlus}
           label="プレイリストを作成"


### PR DESCRIPTION
プレイリストがないときに新しく作成するのはこのアプリの責務でないので、Spotifyに投げます

spotifyに新しいプレイリストを作成するリンクがなさげなのでトップページに飛ばしています