### PR TITLE
Fix #24

### DIFF
--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,13 +1,19 @@
-import { getGoogleAccessToken } from '@/common/auth/Google/getAccessToken'
-import { getSpotifyAccessToken } from '@/common/auth/Spotify/getAccessToken'
+import {
+  GoogleSession,
+  SpotifySession,
+  googleSessionOptions,
+  spotifySessionOptions,
+} from '@/common/auth/ironSessionConfig'
+import { getIronSession } from 'iron-session'
+import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { AppClient } from './_components/AppClient'
 
 const Home = async () => {
-  const googleToken = await getGoogleAccessToken()
-  if (googleToken === undefined) redirect('/app/login/google')
-  const spotifyToken = await getSpotifyAccessToken()
-  if (spotifyToken === undefined) redirect('/app/login/spotify')
+  const googleSession = await getIronSession<GoogleSession>(cookies(), googleSessionOptions)
+  if (googleSession.accessToken === undefined) redirect('/app/login/google')
+  const spotifySession = await getIronSession<SpotifySession>(cookies(), spotifySessionOptions)
+  if (spotifySession.accessToken === undefined) redirect('/app/login/spotify')
 
   return (
     <div>

--- a/src/common/auth/Spotify/getAccessToken.ts
+++ b/src/common/auth/Spotify/getAccessToken.ts
@@ -28,7 +28,9 @@ export const getSpotifyAccessToken = async () => {
   })
 
   const data = await response.json()
-  const parsed: SpotifyAuthResponse = spotifyAuthResponseScheme.parse(data)
+  const parsed: Omit<SpotifyAuthResponse, 'refresh_token'> = spotifyAuthResponseScheme
+    .omit({ refresh_token: true })
+    .parse(data)
 
   session.accessToken = parsed.access_token
   session.expiresAt = Date.now() + parsed.expires_in * 1000


### PR DESCRIPTION
resolve #24

- トークンをリフレッシュする際の型にミスがあったため修正
- `getSpotifyAccessToken()`を呼ぶと、期限が切れていた際にcookieを上書きしようとするが、ServerComponentでcookieの上書きはできないため修正。AccessTokenの有無でログイン済みか確認していただけでAccessTokenを実際に使っていたわけではないため`getIronSession()`から取得するように変更した

当初考えていたtokenの期限の実装にミスはなかったらしい。自分の1時間の時間感覚の方にバグがあった。